### PR TITLE
Renamed several drugs, added skeleton drugs for a lot more.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1904,6 +1904,7 @@
 #include "code\modules\reagents\Chemistry-Reagents\Chemistry-Reagents-Food-Drinks.dm"
 #include "code\modules\reagents\Chemistry-Reagents\Chemistry-Reagents-Medicine.dm"
 #include "code\modules\reagents\Chemistry-Reagents\Chemistry-Reagents-Other.dm"
+#include "code\modules\reagents\Chemistry-Reagents\Chemistry-Reagents-Recreational.dm"
 #include "code\modules\reagents\Chemistry-Reagents\Chemistry-Reagents-Toxins.dm"
 #include "code\modules\reagents\dispenser\_defines.dm"
 #include "code\modules\reagents\dispenser\cartridge.dm"

--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -22,15 +22,20 @@
 #define IS_XENOS   6
 #define IS_RESOMI  7
 
-#define CE_STABLE "stable" // Adrenaline
-#define CE_ANTIBIOTIC "antibiotic" // Spaceacilin
-#define CE_BLOODRESTORE "bloodrestore" // Iron/nutriment
-#define CE_PAINKILLER "painkiller"
-#define CE_ALCOHOL "alcohol" // Liver filtering
-#define CE_ALCOHOL_TOXIC "alcotoxic" // Liver damage
-#define CE_SPEEDBOOST "gofast" // jumpstart
-#define CE_PULSE      "xcardic" // increases or decreases heart rate
-#define CE_NOPULSE    "heartstop" // stops heartbeat
+#define CE_STABLE           "stable" // Adrenaline
+#define CE_ANTIBIOTIC       "antibiotic" // Spaceacilin
+#define CE_BLOODRESTORE     "bloodrestore" // Iron/nutriment
+#define CE_PAINKILLER       "painkiller"
+#define CE_ALCOHOL          "alcohol" // Liver filtering
+#define CE_ALCOHOL_TOXIC    "alcotoxic" // Liver damage
+#define CE_SPEEDBOOST       "gofast" // jumpstart
+#define CE_PULSE            "xcardic" // increases or decreases heart rate
+#define CE_NOPULSE          "heartstop" // stops heartbeat
+#define CE_ANTIRAD          "antirad" // Reduces radiation.
+#define CE_DRUG_SUPPRESSANT "drugsuppress"
+#define CE_LOCK_HARM        "lockharm"
+#define CE_LOCK_HELP        "lockhelp"
+#define CE_THIRDEYE         "thirdeye"
 
 //reagent flags
 #define IGNORE_MOB_SIZE 0x1

--- a/code/game/objects/items/contraband.dm
+++ b/code/game/objects/items/contraband.dm
@@ -35,10 +35,10 @@
 
 /obj/item/weapon/reagent_containers/glass/beaker/vial/random/toxin
 	random_reagent_list = list(
-		list("mindbreaker" = 10, "space_drugs" = 20)	= 3,
+		list("lsd" = 10, "glint" = 20)	= 3,
 		list("carpotoxin" = 15)							= 2,
 		list("impedrezene" = 15)						= 2,
-		list("zombiepowder" = 10)						= 1)
+		list("byphodine" = 10)						= 1)
 
 /obj/item/weapon/reagent_containers/glass/beaker/vial/random/New()
 	..()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -106,7 +106,7 @@
 			user << "<span class='notice'>There's visible lag between left and right pupils' reactions.</span>"
 
 		var/list/pinpoint = list("oxycodone"=1,"morphine"=5)
-		var/list/dilating = list("space_drugs"=5,"mindbreaker"=1)
+		var/list/dilating = list("glint"=5,"lsd"=1)
 		if(H.reagents.has_any_reagent(pinpoint) || H.ingested.has_any_reagent(pinpoint))
 			user << "<span class='notice'>\The [H]'s pupils are already pinpoint and cannot narrow any more.</span>"
 		else if(H.reagents.has_any_reagent(dilating) || H.ingested.has_any_reagent(dilating))

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -129,7 +129,7 @@
 
 /obj/item/weapon/storage/box/syndie_kit/cigarette
 	name = "\improper Tricky smokes"
-	desc = "Comes with the following brands of cigarettes, in this order: 2xFlash, 2xSmoke, 1xMindBreaker. Avoid mixing them up."
+	desc = "Comes with the following brands of cigarettes, in this order: 2xFlash, 2xSmoke, 1xLSD. Avoid mixing them up."
 
 /obj/item/weapon/storage/box/syndie_kit/cigarette/New()
 	..()
@@ -152,10 +152,10 @@
 
 	pack = new /obj/item/weapon/storage/fancy/cigarettes(src)
 	fill_cigarre_package(pack, list("potassium" = 1, "nitrogen" = 1, "silicon" = 1))
-	// Mindbreaker
+	// LSD
 	fill_cigarre_package(pack, list("silicon" = 1.5, "hydrogen" = 1.5))
 
-	pack.desc += " 'MB' has been scribbled on it."
+	pack.desc += " 'LSD' has been scribbled on it."
 
 	new /obj/item/weapon/flame/lighter/zippo(src)
 

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -141,7 +141,7 @@
 		list("antibiotics",   "antibiotic",  0, 80),
 		list("antitoxins",    "anti_toxin",    0, 80),
 		list("nutrients",     "glucose",     0, 80),
-		list("hyronalin",     "hyronalin",     0, 80),
+		list("entolimod",     "entolimod",     0, 80),
 		list("radium",        "radium",        0, 80)
 		)
 
@@ -156,7 +156,7 @@
 		list("antibiotics",   "antibiotic",  0, 20),
 		list("antitoxins",    "anti_toxin",    0, 20),
 		list("nutrients",     "glucose",     0, 80),
-		list("hyronalin",     "hyronalin",     0, 20),
+		list("entolimod",     "entolimod",     0, 20),
 		list("radium",        "radium",        0, 20)
 		)
 

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -94,7 +94,7 @@
 			descriptors |= "radioactive"
 		if(reagents.has_reagent("amatoxin") || reagents.has_reagent("toxin"))
 			descriptors |= "poisonous"
-		if(reagents.has_reagent("psilocybin") || reagents.has_reagent("space_drugs"))
+		if(reagents.has_reagent("psilocybin") || reagents.has_reagent("glint"))
 			descriptors |= "hallucinogenic"
 		if(reagents.has_reagent("styptazine"))
 			descriptors |= "medicinal"

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -288,7 +288,7 @@
 	seed_name = "ambrosia vulgaris"
 	display_name = "ambrosia vulgaris"
 	mutants = list("ambrosiadeus")
-	chems = list("nutriment" = list(1), "space_drugs" = list(1,8), "fotiazine" = list(1,8,1), "styptazine" = list(1,10,1), "toxin" = list(1,10))
+	chems = list("nutriment" = list(1), "glint" = list(1,8), "fotiazine" = list(1,8,1), "styptazine" = list(1,10,1), "toxin" = list(1,10))
 	kitchen_tag = "ambrosia"
 
 /datum/seed/ambrosia/New()
@@ -308,7 +308,7 @@
 	seed_name = "ambrosia deus"
 	display_name = "ambrosia deus"
 	mutants = null
-	chems = list("nutriment" = list(1), "styptazine" = list(1,8), "synaptizine" = list(1,8,1), "jumpstart" = list(1,10,1), "space_drugs" = list(1,10))
+	chems = list("nutriment" = list(1), "styptazine" = list(1,8), "synaptizine" = list(1,8,1), "jumpstart" = list(1,10,1), "glint" = list(1,10))
 	kitchen_tag = "ambrosiadeus"
 
 /datum/seed/ambrosia/deus/New()
@@ -413,7 +413,7 @@
 	seed_name = "liberty cap"
 	display_name = "liberty cap mushrooms"
 	mutants = null
-	chems = list("nutriment" = list(1), "stoxin" = list(3,3), "space_drugs" = list(1,25))
+	chems = list("nutriment" = list(1), "stoxin" = list(3,3), "glint" = list(1,25))
 
 /datum/seed/mushroom/hallucinogenic/strong/New()
 	..()
@@ -1130,7 +1130,7 @@
 	name = "amauri"
 	seed_name = "amauri"
 	display_name = "amauri plant"
-	chems = list("zombiepowder" = list(1,10),"condensedcapsaicin" = list(1,5),"nutriment" = list(1,5))
+	chems = list("byphodine" = list(1,10),"condensedcapsaicin" = list(1,5),"nutriment" = list(1,5))
 
 /datum/seed/amauri/New()
 	..()

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -120,7 +120,7 @@
 	// than a bound as the lists above specify.
 	var/global/list/mutagenic_reagents = list(
 		"radium" =  8,
-		"mutagen" = 15
+		"gc161" = 15
 		)
 
 /obj/machinery/portable_atmospherics/hydroponics/AltClick()

--- a/code/modules/item_worth/reagents.dm
+++ b/code/modules/item_worth/reagents.dm
@@ -411,7 +411,7 @@
 /datum/reagent/ethylredoxrazine
 	value = 3.1
 
-/datum/reagent/hyronalin
+/datum/reagent/entolimod
 	value = 2.3
 
 /datum/reagent/arithrazine
@@ -512,7 +512,7 @@
 /datum/reagent/toxin/potassium_chlorophoride
 	value = 4.5
 
-/datum/reagent/toxin/zombiepowder
+/datum/reagent/toxin/byphodine
 	value = 2.9
 
 /datum/reagent/toxin/fertilizer
@@ -527,7 +527,7 @@
 /datum/reagent/lexorin
 	value = 2.4
 
-/datum/reagent/mutagen
+/datum/reagent/gc161
 	value = 3.1
 
 /datum/reagent/slimejelly
@@ -542,7 +542,7 @@
 /datum/reagent/chloralhydrate/beer2
 	value = 2.2
 
-/datum/reagent/space_drugs
+/datum/reagent/glint
 	value = 2.8
 
 /datum/reagent/serotrotium
@@ -554,7 +554,7 @@
 /datum/reagent/impedrezene
 	value = 1.8
 
-/datum/reagent/mindbreaker
+/datum/reagent/lsd
 	value = 0.6
 
 /datum/reagent/psilocybin

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -476,3 +476,16 @@
 	if(isSynthetic())
 		return 0
 	return !(species.flags & NO_PAIN)
+
+
+/mob/living/carbon/apply_effect(var/effect = 0,var/effecttype = STUN, var/blocked = 0)
+	if(effect && blocked < 100 && effecttype == IRRADIATE)
+		if(chem_effects[CE_ANTIRAD] == 2)
+			return 1
+		else if(chem_effects[CE_ANTIRAD] == 1)
+			radiation += round((effect * blocked_mult(blocked))/2)
+		else
+			radiation += effect * blocked_mult(blocked)
+		updatehealth()
+		return 1
+	. = ..()

--- a/code/modules/mob/living/carbon/human/MedicalSideEffects.dm
+++ b/code/modules/mob/living/carbon/human/MedicalSideEffects.dm
@@ -134,7 +134,7 @@
 // ====
 /datum/medical_effect/itch
 	name = "Itch"
-	triggers = list("space_drugs" = 10)
+	triggers = list("glint" = 10)
 	cures = list("adrenaline")
 	cure_message = "The itching stops..."
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -115,7 +115,7 @@
 
 /obj/item/weapon/pen/reagent/paralysis/New()
 	..()
-	reagents.add_reagent("zombiepowder", 10)
+	reagents.add_reagent("byphodine", 10)
 	reagents.add_reagent("cryptobiolin", 15)
 
 /*

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -1073,7 +1073,7 @@
 	strength = 50
 
 	glass_name = "gin"
-	glass_desc = "A crystal clear glass of Griffeater gin."
+	glass_desc = "A crystal clear glass of gin."
 
 //Base type for alchoholic drinks containing coffee
 /datum/reagent/ethanol/coffee

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -199,7 +199,7 @@
 	M.AdjustParalysis(-1)
 	M.AdjustStunned(-1)
 	M.AdjustWeakened(-1)
-	holder.remove_reagent("mindbreaker", 5)
+	holder.remove_reagent("lsd", 5)
 	M.hallucination = max(0, M.hallucination - 10)
 	M.adjustToxLoss(5 * removed) // It used to be incredibly deadly due to an oversight. Not anymore!
 	M.add_chemical_effect(CE_PAINKILLER, 40)
@@ -284,24 +284,6 @@
 		var/mob/living/carbon/human/H = M
 		H.update_mutations()
 
-/datum/reagent/jumpstart
-	name = "Jumpstart"
-	id = "jumpstart"
-	description = "Jumpstart is a highly effective, highly -illegal-, long-lasting muscle stimulant."
-	taste_description = "acid"
-	reagent_state = LIQUID
-	color = "#FF3300"
-	metabolism = REM * 0.15
-	overdose = REAGENTS_OVERDOSE * 0.5
-
-/datum/reagent/jumpstart/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_DIONA)
-		return
-	if(prob(5))
-		M.emote(pick("twitch", "blink_r", "shiver"))
-	M.add_chemical_effect(CE_SPEEDBOOST, 1)
-	M.add_chemical_effect(CE_PULSE, 2)
-
 /datum/reagent/ethylredoxrazine
 	name = "Ethylredoxrazine"
 	id = "ethylredoxrazine"
@@ -322,10 +304,10 @@
 			if(istype(R, /datum/reagent/ethanol))
 				R.dose = max(R.dose - removed * 5, 0)
 
-/datum/reagent/hyronalin
-	name = "Hyronalin"
-	id = "hyronalin"
-	description = "Hyronalin is a medicinal drug used to counter the effect of radiation poisoning."
+/datum/reagent/entolimod
+	name = "Entolimod"
+	id = "entolimod"
+	description = "An artificial recombinant protein used to counter the effects of radiation poisoning."
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	color = "#408000"
@@ -334,8 +316,8 @@
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
 
-/datum/reagent/hyronalin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.radiation = max(M.radiation - 30 * removed, 0)
+/datum/reagent/entolimod/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	M.add_chemical_effect(CE_ANTIRAD, 1)
 
 /datum/reagent/arithrazine
 	name = "Arithrazine"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Recreational.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Recreational.dm
@@ -1,0 +1,175 @@
+/* TODO: post-psychic power update:
+	ALZ-113 -     lethal virus in humans, triggers latencies in monkeys
+	Ephemerol -   buffs to psychic powers, hallucinations.
+	Nexus -       buffs metaconcerts, makes vulnerable to coercion
+	Accela -      mental enhancer
+	Booster -     may trigger latencies, causes hallucinations
+	Soy sauce -   endgame drug (JDATE), permanent psychological effects and powers
+*/
+
+/* TODO: post-aspect update:
+	Lethe -       amnesiac/calmative - removes a range of aspects
+	Azrael -      Boosts aspects, causes neurological damage.
+*/
+
+/* TODO at some point:
+	Pasceline D - treat bone damage
+	Quietus -     suicide drug
+	Allswell -    calmative
+	Drive -       combat stim, lethal overdose
+	Gravy -       'A nano-drug for acclimating to high-gravity environments.'
+	Kamikaze -    designer amphetamine
+	Powerball -   mania, feral strength
+	Slab -        ammonium chloride and radium. Lethal to humans.
+	Stimutacs -   99% kelp, 1% fugu tetrodotoxin
+	Monocane -   'render the recipient invisible, side effect of inducing insanity.'
+	Tripwire -    synthetic drugs (for robots)
+	Ultrazone -   synthetic drugs (for robots)
+*/
+
+/datum/reagent/lsd
+	name = "LSD"
+	id = "lsd"
+	description = "A powerful hallucinogen, it can cause fatal effects in users."
+	taste_description = "sourness"
+	reagent_state = LIQUID
+	color = "#B31008"
+	metabolism = REM * 0.25
+	overdose = REAGENTS_OVERDOSE
+
+/datum/reagent/lsd/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_DIONA)
+		return
+	M.hallucination = max(M.hallucination, 100)
+
+/datum/reagent/psilocybin
+	name = "Psilocybin"
+	id = "psilocybin"
+	description = "A strong psychotropic derived from certain species of mushroom."
+	taste_description = "mushroom"
+	color = "#E700E7"
+	overdose = REAGENTS_OVERDOSE
+	metabolism = REM * 0.5
+
+/datum/reagent/psilocybin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_DIONA)
+		return
+	M.druggy = max(M.druggy, 30)
+
+	if(dose < 1)
+		M.apply_effect(3, STUTTER)
+		M.make_dizzy(5)
+		if(prob(5))
+			M.emote(pick("twitch", "giggle"))
+	else if(dose < 2)
+		M.apply_effect(3, STUTTER)
+		M.make_jittery(5)
+		M.make_dizzy(5)
+		M.druggy = max(M.druggy, 35)
+		if(prob(10))
+			M.emote(pick("twitch", "giggle"))
+	else
+		M.apply_effect(3, STUTTER)
+		M.make_jittery(10)
+		M.make_dizzy(10)
+		M.druggy = max(M.druggy, 40)
+		if(prob(15))
+			M.emote(pick("twitch", "giggle"))
+
+/datum/reagent/jumpstart
+	name = "Jumpstart"
+	id = "jumpstart"
+	description = "Jumpstart is a highly effective, highly -illegal-, long-lasting muscle stimulant."
+	taste_description = "acid"
+	reagent_state = LIQUID
+	color = "#FF3300"
+	metabolism = REM * 0.15
+	overdose = REAGENTS_OVERDOSE * 0.5
+
+/datum/reagent/jumpstart/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_DIONA)
+		return
+	if(prob(5))
+		M.emote(pick("twitch", "blink_r", "shiver"))
+	M.add_chemical_effect(CE_SPEEDBOOST, 1)
+	M.add_chemical_effect(CE_PULSE, 2)
+
+/datum/reagent/redeye
+	name = "Red Eye"
+	id = "redeye"
+	description = "Red Eye, named for the bloodshot eyes of users, is a potent cocktail of banned combat stimulants."
+	taste_description = "copper"
+	reagent_state = LIQUID
+	color = "#DD0000"
+	metabolism = REM * 0.15
+	overdose = REAGENTS_OVERDOSE * 0.5
+
+/datum/reagent/glint
+	name = "Glint"
+	id = "glint"
+	description = "An illegal chemical compound used as drug."
+	taste_description = "bitterness"
+	taste_mult = 0.4
+	reagent_state = LIQUID
+	color = "#60A584"
+	metabolism = REM * 0.15
+	overdose = REAGENTS_OVERDOSE
+
+/datum/reagent/glint/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_DIONA)
+		return
+	M.druggy = max(M.druggy, 15)
+	if(prob(10) && isturf(M.loc) && !istype(M.loc, /turf/space) && M.canmove && !M.restrained())
+		step(M, pick(cardinal))
+	if(prob(7))
+		M.emote(pick("twitch", "drool", "moan", "giggle"))
+	M.add_chemical_effect(CE_PULSE, -1)
+
+/datum/reagent/pax
+	name = "Pax"
+	id = "pax"
+	description = "A powerful aggression supressant that may cause permanent neurological damage."
+	taste_description = "nothing at all"
+	taste_mult = 0.4
+	reagent_state = LIQUID
+	color = "#CCCCCC"
+	metabolism = REM * 0.15
+	overdose = REAGENTS_OVERDOSE
+
+/datum/reagent/pax/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	M.a_intent = I_HELP
+	M.add_chemical_effect(CE_LOCK_HELP, 1)
+
+/datum/reagent/short
+	name = "Short"
+	id = "short"
+	description = "A broad-spectrum antichemical agent which suppresses many other drugs."
+	taste_description = "wax"
+	reagent_state = LIQUID
+	color = "#FFCCCC"
+	metabolism = REM * 0.15
+
+/datum/reagent/ladder
+	name = "Ladder"
+	id = "ladder"
+	description = "A highly dangerous and powerful aggression enhancer originally developed for military use. Very illegal."
+	taste_description = "acid"
+	reagent_state = LIQUID
+	color = "#FFCC00"
+	metabolism = REM * 0.5
+
+/datum/reagent/ladder/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	M.a_intent = I_HURT
+	M.add_chemical_effect(CE_LOCK_HARM, 1)
+
+/datum/reagent/threeeye
+	name = "Three Eye"
+	id = "threeeye"
+	description = "A dangerously addictive neurotoxin-neurostimulator, rumoured to be capable of opening the third eye of the mind - perhaps permanently."
+	taste_description = "starlight"
+	reagent_state = LIQUID
+	color = "#CCCCFF"
+	metabolism = REM * 0.15
+
+/datum/reagent/threeeye/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	M.add_chemical_effect(CE_THIRDEYE, 1)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -124,9 +124,9 @@
 			H.Weaken(10)
 		M.add_chemical_effect(CE_NOPULSE, 1)
 
-/datum/reagent/toxin/zombiepowder
-	name = "Zombie Powder"
-	id = "zombiepowder"
+/datum/reagent/toxin/byphodine
+	name = "Byphodine"
+	id = "byphodine"
 	description = "A strong neurotoxin that puts the subject into a death-like state."
 	taste_description = "death"
 	reagent_state = SOLID
@@ -134,7 +134,7 @@
 	metabolism = REM
 	strength = 3
 
-/datum/reagent/toxin/zombiepowder/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/toxin/byphodine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	if(alien == IS_DIONA)
 		return
@@ -145,7 +145,7 @@
 	M.tod = stationtime2text()
 	M.add_chemical_effect(CE_NOPULSE, 1)
 
-/datum/reagent/toxin/zombiepowder/Destroy()
+/datum/reagent/toxin/byphodine/Destroy()
 	if(holder && holder.my_atom && ismob(holder.my_atom))
 		var/mob/M = holder.my_atom
 		M.status_flags &= ~FAKEDEATH
@@ -230,24 +230,24 @@
 	if(M.losebreath < 15)
 		M.losebreath++
 
-/datum/reagent/mutagen
-	name = "Unstable mutagen"
-	id = "mutagen"
-	description = "Might cause unpredictable mutations. Keep away from children."
+/datum/reagent/gc161
+	name = "GC-161"
+	id = "gc161"
+	description = "An extremely dangerous mutagenic compound. Keep away from children."
 	taste_description = "slime"
 	taste_mult = 0.9
 	reagent_state = LIQUID
 	color = "#13BC5E"
 
-/datum/reagent/mutagen/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/gc161/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	if(prob(33))
 		affect_blood(M, alien, removed)
 
-/datum/reagent/mutagen/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/gc161/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(prob(67))
 		affect_blood(M, alien, removed)
 
-/datum/reagent/mutagen/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/gc161/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 
 	if(M.isSynthetic())
 		return
@@ -349,28 +349,6 @@
 
 	glass_name = "beer"
 	glass_desc = "A freezing pint of beer"
-/* Drugs */
-
-/datum/reagent/space_drugs
-	name = "Space drugs"
-	id = "space_drugs"
-	description = "An illegal chemical compound used as drug."
-	taste_description = "bitterness"
-	taste_mult = 0.4
-	reagent_state = LIQUID
-	color = "#60A584"
-	metabolism = REM * 0.5
-	overdose = REAGENTS_OVERDOSE
-
-/datum/reagent/space_drugs/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_DIONA)
-		return
-	M.druggy = max(M.druggy, 15)
-	if(prob(10) && isturf(M.loc) && !istype(M.loc, /turf/space) && M.canmove && !M.restrained())
-		step(M, pick(cardinal))
-	if(prob(7))
-		M.emote(pick("twitch", "drool", "moan", "giggle"))
-	M.add_chemical_effect(CE_PULSE, -1)
 
 /datum/reagent/serotrotium
 	name = "Serotrotium"
@@ -424,55 +402,6 @@
 		M.drowsyness = max(M.drowsyness, 3)
 	if(prob(10))
 		M.emote("drool")
-
-/datum/reagent/mindbreaker
-	name = "Mindbreaker Toxin"
-	id = "mindbreaker"
-	description = "A powerful hallucinogen, it can cause fatal effects in users."
-	taste_description = "sourness"
-	reagent_state = LIQUID
-	color = "#B31008"
-	metabolism = REM * 0.25
-	overdose = REAGENTS_OVERDOSE
-
-/datum/reagent/mindbreaker/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_DIONA)
-		return
-	M.hallucination = max(M.hallucination, 100)
-
-/datum/reagent/psilocybin
-	name = "Psilocybin"
-	id = "psilocybin"
-	description = "A strong psycotropic derived from certain species of mushroom."
-	taste_description = "mushroom"
-	color = "#E700E7"
-	overdose = REAGENTS_OVERDOSE
-	metabolism = REM * 0.5
-
-/datum/reagent/psilocybin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_DIONA)
-		return
-	M.druggy = max(M.druggy, 30)
-
-	if(dose < 1)
-		M.apply_effect(3, STUTTER)
-		M.make_dizzy(5)
-		if(prob(5))
-			M.emote(pick("twitch", "giggle"))
-	else if(dose < 2)
-		M.apply_effect(3, STUTTER)
-		M.make_jittery(5)
-		M.make_dizzy(5)
-		M.druggy = max(M.druggy, 35)
-		if(prob(10))
-			M.emote(pick("twitch", "giggle"))
-	else
-		M.apply_effect(3, STUTTER)
-		M.make_jittery(10)
-		M.make_dizzy(10)
-		M.druggy = max(M.druggy, 40)
-		if(prob(15))
-			M.emote(pick("twitch", "giggle"))
 
 /* Transformations */
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -197,10 +197,10 @@
 	required_reagents = list("aluminum" = 1, "silicon" = 1, "acetone" = 1)
 	result_amount = 3
 
-/datum/chemical_reaction/mutagen
-	name = "Unstable mutagen"
-	id = "mutagen"
-	result = "mutagen"
+/datum/chemical_reaction/gc161
+	name = "GC-161"
+	id = "gc161"
+	result = "gc161"
 	required_reagents = list("radium" = 1, "phosphorus" = 1, "hclacid" = 1)
 	result_amount = 3
 
@@ -211,10 +211,10 @@
 	required_reagents = list("aluminum" = 1, "iron" = 1, "acetone" = 1)
 	result_amount = 3
 
-/datum/chemical_reaction/space_drugs
-	name = "Space Drugs"
-	id = "space_drugs"
-	result = "space_drugs"
+/datum/chemical_reaction/glint
+	name = "Glint"
+	id = "glint"
+	result = "glint"
 	required_reagents = list("mercury" = 1, "sugar" = 1, "lithium" = 1)
 	result_amount = 3
 
@@ -239,10 +239,10 @@
 	required_reagents = list("sugar" = 1, "lithium" = 1, "water" = 1)
 	result_amount = 3
 
-/datum/chemical_reaction/hyronalin
-	name = "Hyronalin"
-	id = "hyronalin"
-	result = "hyronalin"
+/datum/chemical_reaction/entolimod
+	name = "Entolimod"
+	id = "entolimod"
+	result = "entolimod"
 	required_reagents = list("radium" = 1, "anti_toxin" = 1)
 	result_amount = 2
 
@@ -250,7 +250,7 @@
 	name = "Arithrazine"
 	id = "arithrazine"
 	result = "arithrazine"
-	required_reagents = list("hyronalin" = 1, "hydrazine" = 1)
+	required_reagents = list("entolimod" = 1, "hydrazine" = 1)
 	result_amount = 2
 
 /datum/chemical_reaction/impedrezene
@@ -401,17 +401,17 @@
 	required_reagents = list("potassium_chloride" = 1, "enzyme" = 1, "chloralhydrate" = 1)
 	result_amount = 4
 
-/datum/chemical_reaction/zombiepowder
-	name = "Zombie Powder"
-	id = "zombiepowder"
-	result = "zombiepowder"
+/datum/chemical_reaction/byphodine
+	name = "Byphodine"
+	id = "byphodine"
+	result = "byphodine"
 	required_reagents = list("carpotoxin" = 5, "stoxin" = 5, "copper" = 5)
 	result_amount = 2
 
-/datum/chemical_reaction/mindbreaker
-	name = "Mindbreaker Toxin"
-	id = "mindbreaker"
-	result = "mindbreaker"
+/datum/chemical_reaction/lsd
+	name = "LSD"
+	id = "lsd"
+	result = "lsd"
 	required_reagents = list("silicon" = 1, "hydrazine" = 1, "anti_toxin" = 1)
 	result_amount = 3
 
@@ -505,14 +505,14 @@
 	name = "Methylphenidate"
 	id = "methylphenidate"
 	result = "methylphenidate"
-	required_reagents = list("mindbreaker" = 1, "hydrazine" = 1)
+	required_reagents = list("lsd" = 1, "hydrazine" = 1)
 	result_amount = 3
 
 /datum/chemical_reaction/citalopram
 	name = "Citalopram"
 	id = "citalopram"
 	result = "citalopram"
-	required_reagents = list("mindbreaker" = 1, "carbon" = 1)
+	required_reagents = list("lsd" = 1, "carbon" = 1)
 	result_amount = 3
 
 
@@ -520,7 +520,7 @@
 	name = "Paroxetine"
 	id = "paroxetine"
 	result = "paroxetine"
-	required_reagents = list("mindbreaker" = 1, "acetone" = 1, "adrenaline" = 1)
+	required_reagents = list("lsd" = 1, "acetone" = 1, "adrenaline" = 1)
 	result_amount = 3
 
 /* Solidification */

--- a/code/modules/reagents/dispenser/cartridge_presets.dm
+++ b/code/modules/reagents/dispenser/cartridge_presets.dm
@@ -74,7 +74,7 @@
 	dexalin/small	volume = CARTRIDGE_VOLUME_SMALL // For the medicine cartridge crate, so it's not too easy to get large amounts of dexalin
 	dylovene	spawn_reagent = "anti_toxin"
 	synaptizine	spawn_reagent = "synaptizine"
-	hyronalin	spawn_reagent = "hyronalin"
+	entolimod	spawn_reagent = "entolimod"
 	arithrazine	spawn_reagent = "arithrazine"
 	alkysine	spawn_reagent = "alkysine"
 	imidazoline	spawn_reagent = "imidazoline"

--- a/code/modules/reagents/dispenser/dispenser_presets.dm
+++ b/code/modules/reagents/dispenser/dispenser_presets.dm
@@ -37,7 +37,7 @@
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/dexalin,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/dylovene,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/synaptizine,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/hyronalin,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/entolimod,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/arithrazine,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/alkysine,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/imidazoline,

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -124,15 +124,15 @@
 		reagents.add_reagent("anti_toxin", 60)
 		update_icon()
 
-/obj/item/weapon/reagent_containers/glass/bottle/mutagen
-	name = "unstable mutagen bottle"
-	desc = "A small bottle of unstable mutagen. Randomly changes the DNA structure of whoever comes in contact."
+/obj/item/weapon/reagent_containers/glass/bottle/gc161
+	name = "\improper GC-161 bottle"
+	desc = "A small bottle of a mutagenic compound. Randomly changes the DNA structure of whoever comes in contact."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-1"
 
 	New()
 		..()
-		reagents.add_reagent("mutagen", 60)
+		reagents.add_reagent("gc161", 60)
 		update_icon()
 
 /obj/item/weapon/reagent_containers/glass/bottle/ammonia

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -211,7 +211,7 @@
 	icon_state = "pill18"
 	New()
 		..()
-		reagents.add_reagent("space_drugs", 15)
+		reagents.add_reagent("glint", 15)
 		reagents.add_reagent("sugar", 15)
 
 /obj/item/weapon/reagent_containers/pill/zoom

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -343,8 +343,8 @@
 	desc = "Contains aggressive drugs meant for torture."
 	New()
 		..()
-		reagents.add_reagent("space_drugs",  5)
-		reagents.add_reagent("mindbreaker",  5)
+		reagents.add_reagent("glint",  5)
+		reagents.add_reagent("lsd",  5)
 		reagents.add_reagent("cryptobiolin", 5)
 		mode = SYRINGE_INJECT
 		update_icon()

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -277,9 +277,9 @@
 		if(c_data)
 			data = c_data
 		else
-			data = pick("styptazine", "fotiazine", "anti_toxin", "adrenaline", "space_drugs", "sugar",
+			data = pick("styptazine", "fotiazine", "anti_toxin", "adrenaline", "glint", "sugar",
 						"morphine", "dexalin", "cryptobiolin", "impedrezene", "jumpstart", "ethylredoxrazine",
-						"mindbreaker", "glucose")
+						"lsd", "glucose")
 		var/datum/reagent/R = chemical_reagents_list[data]
 		name = "[initial(name)] ([initial(R.name)])"
 


### PR DESCRIPTION
- Renamed mindbreaker to LSD.
- Renamed space drugs to glint.
- Renamed zombie powder to byphodine, a Firefly drug that causes the same effect.
- Renamed hyronalin to entolimod, an in-development RL radiation treatment.
- Antirad medication is now taken BEFORE being irradiated and halves the amount of radiation you take.
- Renamed mutagen to GC-161 because references. May revert this or break mutagenic power up between other chemicals.
- Added skeleton definitions for Pax, Short, Ladder, Three Eye, and Red Eye. Also added some commented notes towards other chems.