### PR TITLE
Fixed crates breaking physics

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -54,7 +54,7 @@
 	for(var/obj/O in get_turf(src))
 		if(itemcount >= storage_capacity)
 			break
-		if(O.density || O.anchored || istype(O,/obj/structure/closet))
+		if(O.density || O.anchored || istype(O,/obj/structure/closet) || istype(O,/obj/effect))
 			continue
 		if(istype(O, /obj/structure/bed)) //This is only necessary because of rollerbeds and swivel chairs.
 			var/obj/structure/bed/B = O


### PR DESCRIPTION
You can no longer store light objects in crates, or other effects for that
matter.

They probably need to be overhauled to work the same way closets do, but whatevs, this is just a quick bug fix.